### PR TITLE
fix #2: add header for inet functions

### DIFF
--- a/client.h
+++ b/client.h
@@ -2,6 +2,8 @@
     Author: Niek van Leeuwen
     Date:   07-11-2019
 */
+
+#include <arpa/inet.h>
 #include <ctype.h>
 #include <netinet/in.h>
 #include <stdbool.h>


### PR DESCRIPTION
The functions of #2 needed the header `arpa/inet.h`. I have added them to the header file.